### PR TITLE
Add Ruby HTTParty example

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "name": "Ruby DevContainer",
+  "image": "mcr.microsoft.com/vscode/devcontainers/ruby:0-3.2",
+  "features": {},
+  "postCreateCommand": "bundle install || true"
+}

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Rename this file to .env and replace <YOUR_API_KEY>
+# API key for Holded invoice API
+KEY=<YOUR_API_KEY>

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+/vendor/
+.bundle/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'httparty'
+gem 'dotenv'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,23 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    bigdecimal (3.2.2)
+    csv (3.3.5)
+    dotenv (3.1.8)
+    httparty (0.23.1)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
+    mini_mime (1.1.5)
+    multi_xml (0.7.2)
+      bigdecimal (~> 3.1)
+
+PLATFORMS
+  aarch64-linux
+
+DEPENDENCIES
+  dotenv
+  httparty
+
+BUNDLED WITH
+   2.4.10

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Invoice API Example
+
+This repository demonstrates how to reproduce a bug that appears when using HTTParty in Ruby but not in Postman.
+
+## Prerequisites
+
+- Ruby 3.x
+- Bundler
+- cURL
+
+## Setup
+
+1. Copy `.env.example` to `.env` and insert your API key.
+2. Run `bundle install` to install dependencies (may require internet access).
+
+## Usage
+
+### cURL Script
+
+Execute the `run_curl.sh` script to send the request using `curl`:
+
+```bash
+sh run_curl.sh
+```
+
+### Ruby Script
+
+Run the Ruby version from the `app` folder:
+
+```bash
+ruby app/send_invoice.rb
+```
+
+## Dev Container
+
+A `.devcontainer` configuration is included. Open this repository in VS Code and choose **Reopen in Container** to run the Ruby script inside a containerized environment.

--- a/app/send_invoice.rb
+++ b/app/send_invoice.rb
@@ -1,0 +1,31 @@
+require 'httparty'
+require 'dotenv/load'
+
+API_URL = 'https://api.holded.com/api/invoicing/v1/documents/invoice'
+
+payload = {
+  date: '2025-06-17',
+  contactId: '6851d4e6cc802b4ef101fb7b',
+  items: [
+    {
+      name: 'Test Item',
+      desc: 'Test Item Description',
+      units: 1,
+      sku: nil,
+      serviceId: nil,
+      subtotal: '1.0',
+      discount: 0,
+      tax: 23
+    }
+  ]
+}
+
+headers = {
+  'accept' => 'application/json',
+  'content-type' => 'application/json',
+  'key' => ENV['KEY']
+}
+
+response = HTTParty.post(API_URL, headers: headers, body: payload.to_json)
+puts "Status: #{response.code}"
+puts response.body

--- a/app/send_invoice.rb
+++ b/app/send_invoice.rb
@@ -1,5 +1,6 @@
 require 'httparty'
 require 'dotenv/load'
+require 'json' 
 
 API_URL = 'https://api.holded.com/api/invoicing/v1/documents/invoice'
 
@@ -25,6 +26,8 @@ headers = {
   'content-type' => 'application/json',
   'key' => ENV['KEY']
 }
+
+puts "Headers: #{headers.inspect}"
 
 response = HTTParty.post(API_URL, headers: headers, body: payload.to_json)
 puts "Status: #{response.code}"

--- a/run_curl.sh
+++ b/run_curl.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# Load environment variables from .env if it exists
+if [ -f .env ]; then
+  set -a
+  . ./.env
+  set +a
+fi
+
+curl --location 'https://api.holded.com/api/invoicing/v1/documents/invoice' \
+--header 'accept: application/json' \
+--header 'content-type: application/json' \
+--header "key: $KEY" \
+--data '{
+    "date": "2025-06-17",
+    "contactId": "6851d4e6cc802b4ef101fb7b",
+    "items": [
+        {
+            "name": "Test Item",
+            "desc": "Test Item Description",
+            "units": 1,
+            "sku": null,
+            "serviceId": null,
+            "subtotal": "1.0",
+            "discount": 0,
+            "tax": 23
+        }
+    ]
+}'


### PR DESCRIPTION
## Summary
- add devcontainer setup for Ruby
- add Gemfile with httparty and dotenv
- add example Ruby script using HTTParty
- add cURL script using `.env` for the API key
- document setup and usage in English

## Testing
- `ruby -c app/send_invoice.rb`

------
https://chatgpt.com/codex/tasks/task_e_6851e0d8b50c832696d63a9ed29330d6